### PR TITLE
Eliminate kernel panic when peer node goes diskless in primary-primary mode

### DIFF
--- a/drbd/drbd_actlog.c
+++ b/drbd/drbd_actlog.c
@@ -593,7 +593,7 @@ void drbd_al_complete_io(struct drbd_device *device, struct drbd_interval *i)
 
 	for (enr = first; enr <= last; enr++) {
 		extent = lc_find(device->act_log, enr);
-		if (!extent) {
+		if (!extent || !extent->refcnt == 0) {
 			drbd_err(device, "al_complete_io() called on inactive extent %u\n", enr);
 			continue;
 		}


### PR DESCRIPTION
Backported from 9.0 tree, eliminates "kernel BUG at drbd-8.4.11-1/drbd/lru_cache.c:570!"